### PR TITLE
Use mipi_spi display driver and document ESPHome migration

### DIFF
--- a/config-generator/components/ConfigGeneratorClient.tsx
+++ b/config-generator/components/ConfigGeneratorClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef } from 'react';
+import { useState, useRef, type ReactNode } from 'react';
 import { useTranslations } from 'next-intl';
 import ConfigForm from '@/components/ConfigForm';
 import YamlModal from '@/components/YamlModal';
@@ -9,6 +9,26 @@ import CydDevicePreview from '@/components/CydDevicePreview';
 import { ConfigData } from '@/types/config';
 import { useLocalStorageConfig } from '@/lib/useLocalStorageConfig';
 import { isValidConfig } from '@/lib/configValidation';
+
+/** mipi_spi display driver added in this release (replaces ili9xxx for new configs). */
+const ESPHOME_MIPI_RELEASE_NOTES = 'https://esphome.io/changelog/2025.5.0/';
+
+const esphomeNoticeRich = {
+  strong: (c: ReactNode) => <strong>{c}</strong>,
+  code: (c: ReactNode) => (
+    <code className="bg-gray-100 px-1 rounded text-[0.9em]">{c}</code>
+  ),
+  link: (c: ReactNode) => (
+    <a
+      href={ESPHOME_MIPI_RELEASE_NOTES}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-700 hover:text-blue-800 font-medium underline underline-offset-2"
+    >
+      {c}
+    </a>
+  ),
+};
 
 export default function ConfigGeneratorClient() {
   const t = useTranslations('configGeneratorPage');
@@ -73,6 +93,12 @@ export default function ConfigGeneratorClient() {
 
   return (
     <>
+      <div
+        className="mb-6 rounded-lg border border-blue-100 bg-blue-50/90 px-4 py-3 text-sm text-gray-800 leading-relaxed"
+        role="note"
+      >
+        {t.rich('esphomeNotice', esphomeNoticeRich)}
+      </div>
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
         <div className="space-y-6 min-w-0 col-span-2">
           <ConfigForm config={config} onChange={setConfig} />

--- a/config-generator/components/LocaleProvider.tsx
+++ b/config-generator/components/LocaleProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
 import { NextIntlClientProvider } from 'next-intl';
-import { type Locale, defaultLocale, LOCALE_STORAGE_KEY, locales } from '@/lib/i18n';
+import { type Locale, defaultLocale, defaultTimeZone, LOCALE_STORAGE_KEY, locales } from '@/lib/i18n';
 import enMessages from '@/messages/en.json';
 import deMessages from '@/messages/de.json';
 import frMessages from '@/messages/fr.json';
@@ -67,7 +67,11 @@ export default function LocaleProvider({ children }: { children: ReactNode }) {
 
   return (
     <LocaleContext.Provider value={{ locale, setLocale }}>
-      <NextIntlClientProvider locale={locale} messages={allMessages[locale]}>
+      <NextIntlClientProvider
+        locale={locale}
+        messages={allMessages[locale]}
+        timeZone={defaultTimeZone}
+      >
         {children}
       </NextIntlClientProvider>
     </LocaleContext.Provider>

--- a/config-generator/i18n/request.ts
+++ b/config-generator/i18n/request.ts
@@ -1,4 +1,5 @@
 import { getRequestConfig } from 'next-intl/server';
+import { defaultTimeZone } from '@/lib/i18n';
 import enMessages from '../messages/en.json';
 
 /**
@@ -10,4 +11,5 @@ import enMessages from '../messages/en.json';
 export default getRequestConfig(async () => ({
   locale: 'en',
   messages: enMessages,
+  timeZone: defaultTimeZone,
 }));

--- a/config-generator/lib/i18n.ts
+++ b/config-generator/lib/i18n.ts
@@ -3,6 +3,9 @@ export type Locale = typeof locales[number];
 
 export const defaultLocale: Locale = 'en';
 
+/** Used by next-intl for date/time formatting; fixed zone avoids SSR/client markup drift. */
+export const defaultTimeZone = 'UTC';
+
 export const LOCALE_STORAGE_KEY = 'locale';
 
 export const localeNames: Record<Locale, string> = {

--- a/config-generator/lib/yamlGenerator/boilerplate.ts
+++ b/config-generator/lib/yamlGenerator/boilerplate.ts
@@ -62,6 +62,14 @@ touchscreen:
       : "";
 
   return `
+# ------------------------------------------------------------------------------
+# Display: platform mipi_spi (model ILI9341). The mipi_spi driver shipped in
+# ESPHome 2025.5.0 — https://esphome.io/changelog/2025.5.0/
+# Legacy ili9xxx/st7735 are deprecated in favor of mipi_spi; see
+# https://github.com/esphome/esphome/pull/15416
+#
+# Minimum ESPHome: 2025.5.0. Deprecation warnings for ili9xxx/st7735 from 2026.4.0+.
+# ------------------------------------------------------------------------------
 # ==============================================================================
 esphome:
   name: \${device_name}
@@ -106,7 +114,7 @@ spi:
 ${spiTouchBlock}
 
 display:
-  - platform: ili9xxx
+  - platform: mipi_spi
     id: my_display
     model: ILI9341
     spi_id: tft

--- a/config-generator/messages/de.json
+++ b/config-generator/messages/de.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "YAML generieren",
     "exportJson": "JSON exportieren",
-    "importJson": "JSON importieren"
+    "importJson": "JSON importieren",
+    "esphomeNotice": "Das generierte YAML nutzt die Display-Plattform <code>mipi_spi</code> (ILI9341). <strong>Mindest-ESPHome: 2025.5.0</strong>. Die ältere Plattform <code>ili9xxx</code> wurde durch <code>mipi_spi</code> ersetzt. <link>ESPHome 2025.5.0 – Versionshinweise</link>"
   },
   "deviceSettings": {
     "title": "Geräteeinstellungen",

--- a/config-generator/messages/en.json
+++ b/config-generator/messages/en.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "Generate YAML",
     "exportJson": "Export JSON",
-    "importJson": "Import JSON"
+    "importJson": "Import JSON",
+    "esphomeNotice": "Generated YAML uses the <code>mipi_spi</code> display platform (ILI9341). <strong>Minimum ESPHome: 2025.5.0</strong>. The legacy <code>ili9xxx</code> platform is superseded by <code>mipi_spi</code>. <link>ESPHome 2025.5.0 release notes</link>"
   },
   "deviceSettings": {
     "title": "Device Settings",

--- a/config-generator/messages/es.json
+++ b/config-generator/messages/es.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "Generar YAML",
     "exportJson": "Exportar JSON",
-    "importJson": "Importar JSON"
+    "importJson": "Importar JSON",
+    "esphomeNotice": "El YAML generado usa la plataforma de pantalla <code>mipi_spi</code> (ILI9341). <strong>ESPHome mínimo: 2025.5.0</strong>. La plataforma antigua <code>ili9xxx</code> queda sustituida por <code>mipi_spi</code>. <link>Notas de la versión ESPHome 2025.5.0</link>"
   },
   "deviceSettings": {
     "title": "Configuración del dispositivo",

--- a/config-generator/messages/fr.json
+++ b/config-generator/messages/fr.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "Générer le YAML",
     "exportJson": "Exporter JSON",
-    "importJson": "Importer JSON"
+    "importJson": "Importer JSON",
+    "esphomeNotice": "Le YAML généré utilise la plateforme d'affichage <code>mipi_spi</code> (ILI9341). <strong>ESPHome minimum : 2025.5.0</strong>. L'ancienne plateforme <code>ili9xxx</code> est remplacée par <code>mipi_spi</code>. <link>Notes de version ESPHome 2025.5.0</link>"
   },
   "deviceSettings": {
     "title": "Paramètres de l'appareil",

--- a/config-generator/messages/it.json
+++ b/config-generator/messages/it.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "Genera YAML",
     "exportJson": "Esporta JSON",
-    "importJson": "Importa JSON"
+    "importJson": "Importa JSON",
+    "esphomeNotice": "Lo YAML generato usa la piattaforma display <code>mipi_spi</code> (ILI9341). <strong>ESPHome minimo: 2025.5.0</strong>. La vecchia piattaforma <code>ili9xxx</code> è sostituita da <code>mipi_spi</code>. <link>Note di rilascio ESPHome 2025.5.0</link>"
   },
   "deviceSettings": {
     "title": "Impostazioni dispositivo",

--- a/config-generator/messages/nl.json
+++ b/config-generator/messages/nl.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "YAML genereren",
     "exportJson": "JSON exporteren",
-    "importJson": "JSON importeren"
+    "importJson": "JSON importeren",
+    "esphomeNotice": "De gegenereerde YAML gebruikt het displayplatform <code>mipi_spi</code> (ILI9341). <strong>Minimale ESPHome: 2025.5.0</strong>. Het oude platform <code>ili9xxx</code> is vervangen door <code>mipi_spi</code>. <link>Release-opmerkingen ESPHome 2025.5.0</link>"
   },
   "deviceSettings": {
     "title": "Apparaatinstellingen",

--- a/config-generator/messages/pl.json
+++ b/config-generator/messages/pl.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "Generuj YAML",
     "exportJson": "Eksportuj JSON",
-    "importJson": "Importuj JSON"
+    "importJson": "Importuj JSON",
+    "esphomeNotice": "Wygenerowany YAML używa platformy wyświetlacza <code>mipi_spi</code> (ILI9341). <strong>Minimalna wersja ESPHome: 2025.5.0</strong>. Starsza platforma <code>ili9xxx</code> została zastąpiona przez <code>mipi_spi</code>. <link>Informacje o wydaniu ESPHome 2025.5.0</link>"
   },
   "deviceSettings": {
     "title": "Ustawienia urządzenia",

--- a/config-generator/messages/pt.json
+++ b/config-generator/messages/pt.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "Gerar YAML",
     "exportJson": "Exportar JSON",
-    "importJson": "Importar JSON"
+    "importJson": "Importar JSON",
+    "esphomeNotice": "O YAML gerado usa a plataforma de display <code>mipi_spi</code> (ILI9341). <strong>ESPHome mínimo: 2025.5.0</strong>. A plataforma antiga <code>ili9xxx</code> foi substituída por <code>mipi_spi</code>. <link>Notas de versão ESPHome 2025.5.0</link>"
   },
   "deviceSettings": {
     "title": "Configurações do Dispositivo",

--- a/config-generator/messages/sv.json
+++ b/config-generator/messages/sv.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "Generera YAML",
     "exportJson": "Exportera JSON",
-    "importJson": "Importera JSON"
+    "importJson": "Importera JSON",
+    "esphomeNotice": "Den genererade YAML:en använder displayplattformen <code>mipi_spi</code> (ILI9341). <strong>Minsta ESPHome: 2025.5.0</strong>. Den äldre plattformen <code>ili9xxx</code> ersätts av <code>mipi_spi</code>. <link>Versionsanteckningar ESPHome 2025.5.0</link>"
   },
   "deviceSettings": {
     "title": "Enhetsinställningar",

--- a/config-generator/messages/zh.json
+++ b/config-generator/messages/zh.json
@@ -78,7 +78,8 @@
   "configGeneratorPage": {
     "generateYaml": "生成 YAML",
     "exportJson": "导出 JSON",
-    "importJson": "导入 JSON"
+    "importJson": "导入 JSON",
+    "esphomeNotice": "生成的 YAML 使用 <code>mipi_spi</code> 显示平台（ILI9341）。<strong>最低 ESPHome：2025.5.0</strong>。旧的 <code>ili9xxx</code> 平台已由 <code>mipi_spi</code> 取代。<link>ESPHome 2025.5.0 发布说明</link>"
   },
   "deviceSettings": {
     "title": "设备设置",


### PR DESCRIPTION
This PR updates the generated ESPHome YAML to use the `mipi_spi` display platform (ILI9341) instead of the legacy `ili9xxx` stack.

**Changes**
- Boilerplate display config uses `mipi_spi` with inline comments covering minimum ESPHome **2025.5.0**, the **2025.5.0** changelog link, `ili9xxx` deprecation context (including PR #15416), and **2026.4.0** deprecation warnings for legacy platforms.
- Config Generator page: localized notice with link to the [ESPHome 2025.5.0 release notes](https://esphome.io/changelog/2025.5.0/).
- next-intl: set global `timeZone` (UTC) on server and client to resolve `ENVIRONMENT_FALLBACK` during build.

Made with [Cursor](https://cursor.com)